### PR TITLE
日付リストの更新

### DIFF
--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -1,0 +1,27 @@
+import { filterFromToday } from "@/src/utils/date";
+import { describe, expect, test } from "vitest";
+
+describe("filterFromToday", () => {
+  test("実施日の出力：今日が月曜なら当日、月曜以外なら次の月曜", () => {
+    const dateList = [
+      "2025/11/16(日)",
+      "2025/11/17(月)",
+      "2025/11/18(火)",
+      "2025/11/19(水)",
+      "2025/11/20(木)",
+      "2025/11/21(金)",
+      "2025/11/22(土)",
+      "2025/11/23(日)",
+      "2025/11/24(月)",
+      "2025/11/25(火)",
+    ];
+    const pastResult = filterFromToday(dateList, new Date("2025-11-16"));
+    const todayResult = filterFromToday(dateList, new Date("2025-11-17"));
+    const featureResult = filterFromToday(dateList, new Date("2025-11-20"));
+
+    expect(Array.isArray(todayResult)).toBe(true);
+    expect(pastResult[0]).toBe("2025/11/17(月)");
+    expect(todayResult[0]).toBe("2025/11/17(月)");
+    expect(featureResult[0]).toBe("2025/11/24(月)");
+  });
+});

--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -1,6 +1,20 @@
 import { filterFromToday, mondays } from "@/src/utils/date";
-import { isMonday } from "date-fns";
+import { isMonday, parse } from "date-fns";
 import { describe, expect, test } from "vitest";
+
+test("日付リストが十分な期間をカバーしている（残り3年以上）", () => {
+  const lastDateString = mondays[mondays.length - 1];
+  const parseDateString = lastDateString.replace(/\([^)]*\)/, "");
+  const lastDate = parse(parseDateString, "yyyy/M/d", new Date());
+
+  // 日付をミリ秒に変換して最終日と今日の差を計算
+  // (1000 * 60 * 60 * 24 * 365.25): 1年をミリ秒で計算する（1秒 * 1分 * 1時間 * 1日 * 1年）
+  const yearsLeft =
+    (lastDate.getTime() - new Date().getTime()) /
+    (1000 * 60 * 60 * 24 * 365.25);
+
+  expect(yearsLeft).toBeGreaterThan(3);
+});
 
 describe("generateAllWorkingMondays", () => {
   test("配列の中身が全て月曜日である", () => {

--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -1,5 +1,12 @@
-import { filterFromToday } from "@/src/utils/date";
+import { filterFromToday, mondays } from "@/src/utils/date";
+import { isMonday } from "date-fns";
 import { describe, expect, test } from "vitest";
+
+describe("generateAllWorkingMondays", () => {
+  test("配列の中身が全て月曜日である", () => {
+    mondays.map((date) => expect(isMonday(date)).toBe(true));
+  });
+});
 
 describe("filterFromToday", () => {
   test("実施日の出力：今日が月曜なら当日、月曜以外なら次の月曜", () => {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -23,8 +23,8 @@ function generateAllWorkingMondays(startDate: Date): string[] {
     .map((date) => format(date, "yyyy/M/d(E)", { locale: ja }));
 }
 
-function filterFromToday(mondays: string[]): string[] {
-  const today = startOfDay(new Date());
+export function filterFromToday(mondays: string[]): string[] {
+ const today = startOfDay(new Date());
   const startMonday = isMonday(today) ? today : nextMonday(today);
 
   return mondays.filter((monday) => {
@@ -36,4 +36,3 @@ function filterFromToday(mondays: string[]): string[] {
 }
 
 export const mondays = generateAllWorkingMondays(PROJECT_START_DATE);
-export const futureMondaysFromToday = filterFromToday(mondays);

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,4 +1,13 @@
-import { addYears, eachDayOfInterval, format, isMonday } from "date-fns";
+import {
+  addYears,
+  eachDayOfInterval,
+  format,
+  isBefore,
+  isMonday,
+  nextMonday,
+  parse,
+  startOfDay,
+} from "date-fns";
 import { ja } from "date-fns/locale";
 
 // プロジェクト開始日（固定基準日）
@@ -14,4 +23,17 @@ function generateAllWorkingMondays(startDate: Date): string[] {
     .map((date) => format(date, "yyyy/M/d(E)", { locale: ja }));
 }
 
+function filterFromToday(mondays: string[]): string[] {
+  const today = startOfDay(new Date());
+  const startMonday = isMonday(today) ? today : nextMonday(today);
+
+  return mondays.filter((monday) => {
+    // 文字列("2025/10/10(月)")とDateを比較するとフィルタリングが動作しない可能性があるため(月)をパースする
+    const dateString = monday.replace(/\([^)]*\)/, "");
+    const date = parse(dateString, "yyyy/M/d", new Date());
+    return !isBefore(date, startMonday);
+  });
+}
+
 export const mondays = generateAllWorkingMondays(PROJECT_START_DATE);
+export const futureMondaysFromToday = filterFromToday(mondays);

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -23,8 +23,11 @@ function generateAllWorkingMondays(startDate: Date): string[] {
     .map((date) => format(date, "yyyy/M/d(E)", { locale: ja }));
 }
 
-export function filterFromToday(mondays: string[]): string[] {
- const today = startOfDay(new Date());
+export function filterFromToday(
+  mondays: string[],
+  baseDate: Date = new Date()
+): string[] {
+  const today = startOfDay(baseDate);
   const startMonday = isMonday(today) ? today : nextMonday(today);
 
   return mondays.filter((monday) => {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -11,6 +11,7 @@ import {
 import { ja } from "date-fns/locale";
 
 // プロジェクト開始日（固定基準日）
+// NOTE: ペア整合性維持のため、この日付は変更しないこと
 const PROJECT_START_DATE = new Date("2025-08-04");
 
 function generateAllWorkingMondays(startDate: Date): string[] {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,9 +1,17 @@
-import { eachDayOfInterval, format, isMonday } from "date-fns";
+import { addYears, eachDayOfInterval, format, isMonday } from "date-fns";
 import { ja } from "date-fns/locale";
 
-export const mondays = eachDayOfInterval({
-  start: new Date("2025-08-01"),
-  end: new Date("2026-12-31"),
-})
-  .filter((day) => isMonday(day))
-  .map((date) => format(date, "yyyy/M/d(E)", { locale: ja }));
+// プロジェクト開始日（固定基準日）
+const PROJECT_START_DATE = new Date("2025-08-04");
+
+function generateAllWorkingMondays(startDate: Date): string[] {
+  const endDate = addYears(startDate, 5);
+  return eachDayOfInterval({
+    start: startDate,
+    end: endDate,
+  })
+    .filter((day) => isMonday(day))
+    .map((date) => format(date, "yyyy/M/d(E)", { locale: ja }));
+}
+
+export const mondays = generateAllWorkingMondays(PROJECT_START_DATE);

--- a/src/utils/member.test.ts
+++ b/src/utils/member.test.ts
@@ -214,7 +214,7 @@ describe("generateCTSchedules", () => {
         { id: 2, name: "Bob", participate: true },
       ],
     ];
-    const manyRounds: Round[] = Array(100).fill(round);
+    const manyRounds: Round[] = Array(300).fill(round);
     const result = generateCTSchedules(manyRounds);
     expect(result).toHaveLength(mondays.length);
   });

--- a/src/utils/member.test.ts
+++ b/src/utils/member.test.ts
@@ -142,6 +142,7 @@ describe("generateRoundRobinPairs", () => {
 });
 
 describe("generateCTSchedules", () => {
+  const testData = ["2025/8/4(月)", "2025/8/11(月)", "2025/8/18(月)"];
   test("3ラウンドから3つのスケジュールを生成する", () => {
     const threePersonRounds: Round[] = [
       [
@@ -171,7 +172,7 @@ describe("generateCTSchedules", () => {
       { date: "2025/8/11(月)", round: threePersonRounds[1] },
       { date: "2025/8/18(月)", round: threePersonRounds[2] },
     ];
-    const result = generateCTSchedules(threePersonRounds);
+    const result = generateCTSchedules(threePersonRounds, testData);
 
     // 生成されたスケジュールの数が正しいか
     expect(result).toHaveLength(3);
@@ -202,7 +203,7 @@ describe("generateCTSchedules", () => {
         ],
       ],
     ];
-    const result = generateCTSchedules(rounds);
+    const result = generateCTSchedules(rounds, testData);
 
     expect(result).toHaveLength(1);
   });
@@ -215,8 +216,8 @@ describe("generateCTSchedules", () => {
       ],
     ];
     const manyRounds: Round[] = Array(300).fill(round);
-    const result = generateCTSchedules(manyRounds);
-    expect(result).toHaveLength(mondays.length);
+    const result = generateCTSchedules(manyRounds, testData);
+    expect(result).toHaveLength(testData.length);
   });
 
   test("連続する月曜日が正しい順序で割り当てられる", () => {
@@ -243,7 +244,7 @@ describe("generateCTSchedules", () => {
         [{ id: 1, name: "Alice", participate: true }, null],
       ],
     ];
-    const result = generateCTSchedules(rounds);
+    const result = generateCTSchedules(rounds, testData);
     expect(result[0].date).toBe(mondays[0]);
     expect(result[1].date).toBe(mondays[1]);
     expect(result[2].date).toBe(mondays[2]);

--- a/src/utils/member.ts
+++ b/src/utils/member.ts
@@ -1,5 +1,5 @@
 import { Member } from "@/app/actions";
-import { mondays } from "@/src/utils/date";
+import { futureMondaysFromToday } from "@/src/utils/date";
 
 type Pair = [Member, Member | null];
 export type Round = Pair[];
@@ -84,9 +84,13 @@ type Schedule = CT[];
  * ```
  */
 
-export function generateCTSchedules(rounds: Round[]): Schedule {
-  return mondays.slice(0, rounds.length).map((monday, mondayIndex) => ({
-    date: monday,
-    round: rounds[mondayIndex],
+export function generateCTSchedules(
+  rounds: Round[],
+  dateList: string[] = futureMondaysFromToday
+): Schedule {
+  // 組み合わせをdateList.lengthの数に制限する
+  return rounds.slice(0, dateList.length).map((round, index) => ({
+    date: dateList[index],
+    round,
   }));
 }

--- a/src/utils/member.ts
+++ b/src/utils/member.ts
@@ -1,5 +1,5 @@
 import { Member } from "@/app/actions";
-import { futureMondaysFromToday } from "@/src/utils/date";
+import { filterFromToday, mondays } from "@/src/utils/date";
 
 type Pair = [Member, Member | null];
 export type Round = Pair[];
@@ -83,6 +83,8 @@ type Schedule = CT[];
  * ];
  * ```
  */
+
+const futureMondaysFromToday = filterFromToday(mondays);
 
 export function generateCTSchedules(
   rounds: Round[],


### PR DESCRIPTION
close #43

## やったこと
- 5年先まで取得
- 過去分を表示しないようフィルタリングする `filterFromToday` 関数を作成
  - 当日が月曜の場合は当日を表示する
- 日付の扱いに関するテストを作成

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Generate Mondays for 5 years from a fixed start date, add a filter to start from today/next Monday, and update schedule generation to accept a date list with corresponding tests.
> 
> - **Utils/date**
>   - Add `PROJECT_START_DATE` and `generateAllWorkingMondays` to build 5-year `mondays` list.
>   - Add `filterFromToday(mondays, baseDate)` to start from today (or next Monday), parsing `yyyy/M/d(E)` strings.
> - **Utils/member**
>   - Update `generateCTSchedules(rounds, dateList=filterFromToday(mondays))` and cap output by `dateList.length`.
> - **Tests**
>   - New `date.test.ts`: verifies list horizon (>3 years), all entries are Mondays, and `filterFromToday` behavior.
>   - Update `member.test.ts`: pass custom date list, adjust length limits and order assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d87bea7e66b0cf00c99ef330375c59c39812f4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->