### PR TITLE
組み合わせが常にround[0]になるのを修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -66,7 +66,7 @@ export default async function Home() {
           <p>
             現在の参加者：
             <Link href="/member" className="underline">
-              {ctSchedules.length}人
+              {memberData.length}人
             </Link>
           </p>
         </section>

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -12,7 +12,7 @@ import { ja } from "date-fns/locale";
 
 // プロジェクト開始日（固定基準日）
 // NOTE: ペア整合性維持のため、この日付は変更しないこと
-const PROJECT_START_DATE = new Date("2025-08-04");
+export const PROJECT_START_DATE = new Date("2025-08-04");
 
 function generateAllWorkingMondays(startDate: Date): string[] {
   const endDate = addYears(startDate, 5);


### PR DESCRIPTION
## やったこと
- 組み合わせが変わらない（常に `round[0]` を取得している）事象を修正

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rotate CT schedule rounds per week using PROJECT_START_DATE and display participant count from member data.
> 
> - **Scheduling Logic**:
>   - `generateCTSchedules` now offsets rounds by the number of weeks since `PROJECT_START_DATE`, rotating with `weekOffset` instead of always using `rounds[0]` (imports `PROJECT_START_DATE`, uses `parse`).
>   - Handles empty `rounds` by returning an empty schedule.
> - **Date Utils**:
>   - Exports `PROJECT_START_DATE` from `src/utils/date.ts` for reuse.
> - **UI**:
>   - Participant count on `src/app/page.tsx` now uses `memberData.length` instead of `ctSchedules.length`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab9933b2f1ecdfa7f6aca990c78d0a468bf978f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->