### PR TITLE
祝日をスキップする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,11 +18,12 @@ bun run build
 # Lint実行
 bun run lint
 
-# テスト実行
-bun run test
+# テスト実行（bun組み込みテストランナーを使用）
+# ※ bun run test (vitest) はpath aliasエラーが出るため bun test を使う
+bun test
 
 # 特定ファイルのテストのみ実行
-bun run test src/utils/member.test.ts
+bun test src/utils/member.test.ts
 ```
 
 ## Architecture
@@ -143,7 +144,8 @@ const handleSubmit = async (formData: FormData) => {
 
 ## Testing
 
-- **Test Framework**: Vitest
+- **Test Runner**: `bun test`（bun組み込みテストランナー）
+  - `bun run test`（vitest）はpath alias（`@/src/...`）でエラーになるため使わない
 - **Test Files**: `*.test.ts`形式
 - **Coverage**: `src/utils/`のビジネスロジックに対してユニットテスト実装済み
 - **Focus**: ラウンドロビンアルゴリズム、日付ユーティリティ

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -132,7 +132,7 @@ export async function deleteUser(id: number) {
 
 export async function getHolidays(): Promise<Holiday[]> {
   const result = await sql`
-    SELECT * FROM public.holidays
+    SELECT TO_CHAR(date, 'YYYY-MM-DD') as date, name FROM public.holidays
   `;
   return result as Holiday[];
 }

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,4 +1,5 @@
 "use server";
+import { Holiday } from "@/src/utils/holiday";
 import { neon } from "@neondatabase/serverless";
 
 function getDataBaseUrl() {
@@ -58,7 +59,7 @@ export async function upsertUserFromSlack(slackUser: {
 }
 
 export async function getUserBySlackId(
-  slackUserId: string
+  slackUserId: string,
 ): Promise<User | null> {
   const result = await sql`
     SELECT * FROM public.users
@@ -74,7 +75,7 @@ export async function getUserBySlackId(
 
 export async function setUser(
   slackUserId: string,
-  formData: FormData
+  formData: FormData,
 ): Promise<User> {
   const displayName = formData.get("displayName");
   const employeeNumber = formData.get("employeeNumber");
@@ -103,12 +104,11 @@ export async function getUsers(): Promise<User[]> {
   return data as User[];
 }
 
-
 export async function updateUser(
   id: number,
   displayName: string,
   employeeNumber: number,
-  participate: boolean
+  participate: boolean,
 ) {
   const result = await sql`
     UPDATE users
@@ -128,4 +128,24 @@ export async function deleteUser(id: number) {
     RETURNING slack_display_name;
   `;
   return result[0]?.slack_display_name;
+}
+
+export async function getHolidays(): Promise<Holiday[]> {
+  const result = await sql`
+    SELECT * FROM public.holidays
+  `;
+  return result as Holiday[];
+}
+
+export async function saveHolidaysToDB(holidays: Holiday[]): Promise<void> {
+  for (const holiday of holidays) {
+    await sql`
+      INSERT INTO holidays(date, name)
+      VALUES(${holiday.date}, ${holiday.name})
+      ON CONFLICT(date)
+      DO UPDATE SET
+        name = EXCLUDED.name,
+        updated_at = NOW()
+    `;
+  }
 }

--- a/src/app/api/cron/notify-ct-pairs/route.ts
+++ b/src/app/api/cron/notify-ct-pairs/route.ts
@@ -11,7 +11,7 @@ import type { CT } from "@/src/utils/member";
 export async function GET(request: Request) {
   const authHeader = request.headers.get("authorization");
   if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
-    return NextResponse.json({ error: "Unauthorized", status: 401 });
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   try {

--- a/src/app/api/cron/notify-ct-pairs/route.ts
+++ b/src/app/api/cron/notify-ct-pairs/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getUsers } from "@/app/actions";
+import { getHolidays, getUsers } from "@/app/actions";
 import {
   generateCTSchedules,
   generateRoundRobinPairs,
@@ -16,8 +16,10 @@ export async function GET(request: Request) {
 
   try {
     const users = await getUsers();
+    const holidays = await getHolidays();
+
     const round = generateRoundRobinPairs(users);
-    const schedules = generateCTSchedules(round);
+    const schedules = generateCTSchedules(round, undefined, holidays);
     const currentCT = getCurrentWeekCT(schedules);
 
     if (!currentCT) {
@@ -25,6 +27,15 @@ export async function GET(request: Request) {
         { message: "次回のCTスケジュールが見つかりません" },
         { status: 404 },
       );
+    }
+
+    if (currentCT.isHoliday) {
+      return NextResponse.json({
+        success: true,
+        message: "祝日のため通知をスキップしました",
+        date: currentCT.date,
+        holidayName: currentCT.holidayName,
+      });
     }
 
     const channelId = process.env.SLACK_CHANNEL_ID;
@@ -38,7 +49,7 @@ export async function GET(request: Request) {
     return NextResponse.json({
       success: true,
       date: currentCT.date,
-      pairsCount: currentCT.round.length,
+      pairsCount: currentCT.round?.length,
     });
   } catch (error) {
     console.error("Slack通知エラー:", error);
@@ -48,10 +59,11 @@ export async function GET(request: Request) {
 
 function buildMessage(ct: CT): string {
   const lines = ["🗣️ 本日のCTペア", "https://ct-schedule.vercel.app/", ""];
-  const pairLines = ct.round.map(([user1, user2]) => {
-    const pair1 = `<@${user1.slack_user_id}>`;
-    const pair2 = user2 ? `<@${user2.slack_user_id}>` : "お休み";
-    return `• ${pair1} ${pair2}`;
-  });
+  const pairLines =
+    ct.round?.map(([user1, user2]) => {
+      const pair1 = `<@${user1.slack_user_id}>`;
+      const pair2 = user2 ? `<@${user2.slack_user_id}>` : "お休み";
+      return `• ${pair1} ${pair2}`;
+    }) ?? [];
   return [...lines, ...pairLines].join("\n");
 }

--- a/src/app/api/cron/sync-holidays/route.ts
+++ b/src/app/api/cron/sync-holidays/route.ts
@@ -6,7 +6,7 @@ import { NextResponse } from "next/server";
 export async function GET(request: Request) {
   const authHeader = request.headers.get("authorization");
   if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
-    return NextResponse.json({ error: "Unauthorized", status: 401 });
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   try {

--- a/src/app/api/cron/sync-holidays/route.ts
+++ b/src/app/api/cron/sync-holidays/route.ts
@@ -3,7 +3,12 @@ import { fetchHolidaysFromGoogle } from "@/src/utils/google-calendar";
 import { addYears } from "date-fns";
 import { NextResponse } from "next/server";
 
-export async function GET() {
+export async function GET(request: Request) {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: "Unauthorized", status: 401 });
+  }
+
   try {
     const fetchHolidays = await fetchHolidaysFromGoogle(
       new Date(),

--- a/src/app/api/cron/sync-holidays/route.ts
+++ b/src/app/api/cron/sync-holidays/route.ts
@@ -1,0 +1,21 @@
+import { saveHolidaysToDB } from "@/app/actions";
+import { fetchHolidaysFromGoogle } from "@/src/utils/google-calendar";
+import { addYears } from "date-fns";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  try {
+    const fetchHolidays = await fetchHolidaysFromGoogle(
+      new Date(),
+      addYears(new Date(), 5),
+    );
+    await saveHolidaysToDB(fetchHolidays);
+
+    return NextResponse.json({
+      success: true,
+      count: fetchHolidays.length,
+    });
+  } catch (error) {
+    return NextResponse.json({ error: "失敗" }, { status: 500 });
+  }
+}

--- a/src/app/components/CTScheduleCard.tsx
+++ b/src/app/components/CTScheduleCard.tsx
@@ -1,5 +1,6 @@
 import { Avatar, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
+import { cn } from "@/src/lib/utils";
 import { CT } from "@/src/utils/member";
 
 type Props = {
@@ -10,15 +11,22 @@ type Props = {
 export const CTScheduleCard = ({ schedule, index }: Props) => {
   return (
     <div
-      className={`border rounded-lg p-4 shadow-sm flex-shrink-0 min-w-[300px] ${
-        index === 0 && "border-2 border-gray-400"
-      }`}
+      className={cn(
+        "border rounded-lg p-4 shadow-sm flex-shrink-0 min-w-[300px]",
+        index === 0 && "border-2 border-gray-400",
+        schedule.isHoliday && "bg-gray-100"
+      )}
     >
       <h2 className="text-lg font-semibold mb-4 text-center">
         <time dateTime={schedule.date}>{schedule.date}</time>
       </h2>
+      {schedule.isHoliday && (
+        <Badge className="grid text-center bg-gray-400 rounded-full shadow-none hover:bg-gray-400">
+          {schedule.holidayName}
+        </Badge>
+      )}
       <div className="flex flex-col gap-2">
-        {schedule.round.map((pair, pairIndex) => (
+        {schedule.round?.map((pair, pairIndex) => (
           <div
             key={pairIndex}
             className="flex items-center gap-2 p-3 bg-gray-50 rounded-md"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { getUsers, getUserBySlackId } from "@/app/actions";
+import { getUsers, getUserBySlackId, getHolidays } from "@/app/actions";
 import { auth, signOut } from "@/auth";
 import { CTScheduleCard } from "@/components/CTScheduleCard";
 import { SetupDataDialog } from "@/components/SetupDataDialog";
@@ -24,9 +24,10 @@ export default async function Home() {
   const user = session?.user?.slack_user_id
     ? await getUserBySlackId(session.user.slack_user_id)
     : null;
+  const holidays = await getHolidays();
 
   const rounds = generateRoundRobinPairs(memberData);
-  const ctSchedules = generateCTSchedules(rounds);
+  const ctSchedules = generateCTSchedules(rounds, undefined, holidays);
 
   const participantsMember = memberData.filter((member) => member.participate);
 

--- a/src/utils/google-calendar.ts
+++ b/src/utils/google-calendar.ts
@@ -1,7 +1,4 @@
-export type Holiday = {
-  date: string;
-  name: string;
-};
+import { Holiday } from "@/src/utils/holiday";
 
 type GoogleCalendarEvent = {
   start: { date: string };

--- a/src/utils/google-calendar.ts
+++ b/src/utils/google-calendar.ts
@@ -1,0 +1,37 @@
+export type Holiday = {
+  date: string;
+  name: string;
+};
+
+type GoogleCalendarEvent = {
+  start: { date: string };
+  summary: string;
+};
+
+type GoogleCalendarResponse = {
+  items: GoogleCalendarEvent[];
+};
+
+const CALENDAR_ID = "japanese__ja@holiday.calendar.google.com";
+
+export async function fetchHolidaysFromGoogle(
+  startDate: Date,
+  endDate: Date,
+): Promise<Holiday[]> {
+  const url = `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(CALENDAR_ID)}/events`;
+
+  const params = new URLSearchParams({
+    key: process.env.GOOGLE_CALENDAR_API_KEY!,
+    timeMin: startDate.toISOString(),
+    timeMax: endDate.toISOString(),
+    singleEvents: "true",
+  });
+
+  const response = await fetch(`${url}?${params}`);
+  const data: GoogleCalendarResponse = await response.json();
+
+  return data.items.map((item) => ({
+    date: item.start.date,
+    name: item.summary,
+  }));
+}

--- a/src/utils/google-calendar.ts
+++ b/src/utils/google-calendar.ts
@@ -14,6 +14,26 @@ type GoogleCalendarResponse = {
 
 const CALENDAR_ID = "japanese__ja@holiday.calendar.google.com";
 
+const NATIONAL_HOLIDAYS = [
+  "元日",
+  "成人の日",
+  "建国記念の日",
+  "天皇誕生日",
+  "春分の日",
+  "昭和の日",
+  "憲法記念日",
+  "みどりの日",
+  "こどもの日",
+  "海の日",
+  "山の日",
+  "敬老の日",
+  "秋分の日",
+  "スポーツの日",
+  "文化の日",
+  "勤労感謝の日",
+  "振替休日",
+];
+
 export async function fetchHolidaysFromGoogle(
   startDate: Date,
   endDate: Date,
@@ -30,8 +50,12 @@ export async function fetchHolidaysFromGoogle(
   const response = await fetch(`${url}?${params}`);
   const data: GoogleCalendarResponse = await response.json();
 
-  return data.items.map((item) => ({
-    date: item.start.date,
-    name: item.summary,
-  }));
+  return data.items
+    .filter((item) =>
+      NATIONAL_HOLIDAYS.some((holiday) => item.summary.includes(holiday)),
+    )
+    .map((item) => ({
+      date: item.start.date,
+      name: item.summary,
+    }));
 }

--- a/src/utils/holiday.test.ts
+++ b/src/utils/holiday.test.ts
@@ -1,3 +1,4 @@
+import { isHolidayMonday } from "@/src/utils/holiday";
 import { expect, test, describe } from "vitest";
 
 describe("isHolidayMonday", () => {
@@ -8,14 +9,14 @@ describe("isHolidayMonday", () => {
   ];
 
   test("祝日かつ月曜日の場合trueを返す", () => {
-    expect(isHolidayMonday("2025/9/15(月)", [holidays])).toBe(true);
+    expect(isHolidayMonday("2025/9/15(月)", holidays)).toBe(true);
   });
 
   test("祝日だが月曜日ではない場合falseを返す", () => {
-    expect(isHolidayMonday("2025/9/23(火)", [holidays])).toBe(false);
+    expect(isHolidayMonday("2025/9/23(火)", holidays)).toBe(false);
   });
 
   test("月曜日だが祝日ではない場合falseを返す", () => {
-    expect(isHolidayMonday("2025/9/22(月)", [holidays])).toBe(false);
+    expect(isHolidayMonday("2025/9/22(月)", holidays)).toBe(false);
   });
 });

--- a/src/utils/holiday.test.ts
+++ b/src/utils/holiday.test.ts
@@ -1,4 +1,4 @@
-import { isHolidayMonday } from "@/src/utils/holiday";
+import { getHolidayName, isHolidayMonday } from "@/src/utils/holiday";
 import { expect, test, describe } from "vitest";
 
 describe("isHolidayMonday", () => {
@@ -18,5 +18,18 @@ describe("isHolidayMonday", () => {
 
   test("月曜日だが祝日ではない場合falseを返す", () => {
     expect(isHolidayMonday("2025/9/22(月)", holidays)).toBe(false);
+  });
+});
+
+describe("getHolidayName", () => {
+  const holidays = [
+    { date: "2025-09-15", name: "敬老の日" },
+    { date: "2025-09-23", name: "秋分の日" },
+    { date: "2025-11-03", name: "文化の日" },
+  ];
+
+  test("祝日の場合は名前を返し、そうでない場合はnullを返す", () => {
+    expect(getHolidayName("2025/9/15(月)", holidays)).toBe("敬老の日");
+    expect(getHolidayName("2025/9/22(月)", holidays)).toBe(null);
   });
 });

--- a/src/utils/holiday.test.ts
+++ b/src/utils/holiday.test.ts
@@ -28,8 +28,13 @@ describe("getHolidayName", () => {
     { date: "2025-11-03", name: "文化の日" },
   ];
 
-  test("祝日の場合は名前を返し、そうでない場合はnullを返す", () => {
+  test("祝日の場合は名前を返す", () => {
     expect(getHolidayName("2025/9/15(月)", holidays)).toBe("敬老の日");
-    expect(getHolidayName("2025/9/22(月)", holidays)).toBe(null);
+  });
+
+  test("祝日ではない場合はエラーを投げる", () => {
+    expect(() => getHolidayName("2025/9/22(月)", holidays)).toThrow(
+      "Holiday not found for date: 2025/9/22(月)",
+    );
   });
 });

--- a/src/utils/holiday.test.ts
+++ b/src/utils/holiday.test.ts
@@ -1,0 +1,21 @@
+import { expect, test, describe } from "vitest";
+
+describe("isHolidayMonday", () => {
+  const holidays = [
+    { date: "2025-09-15", name: "敬老の日" },
+    { date: "2025-09-23", name: "秋分の日" },
+    { date: "2025-11-03", name: "文化の日" },
+  ];
+
+  test("祝日かつ月曜日の場合trueを返す", () => {
+    expect(isHolidayMonday("2025/9/15(月)", [holidays])).toBe(true);
+  });
+
+  test("祝日だが月曜日ではない場合falseを返す", () => {
+    expect(isHolidayMonday("2025/9/23(火)", [holidays])).toBe(false);
+  });
+
+  test("月曜日だが祝日ではない場合falseを返す", () => {
+    expect(isHolidayMonday("2025/9/22(月)", [holidays])).toBe(false);
+  });
+});

--- a/src/utils/holiday.ts
+++ b/src/utils/holiday.ts
@@ -1,6 +1,6 @@
 import { format, isMonday, parse } from "date-fns";
 
-type Holiday = {
+export type Holiday = {
   date: string;
   name: string;
 };

--- a/src/utils/holiday.ts
+++ b/src/utils/holiday.ts
@@ -19,3 +19,16 @@ export function isHolidayMonday(
 
   return isMondayFlag && isHolidayFlag;
 }
+
+export function getHolidayName(
+  targetDate: string,
+  holidays: Holiday[],
+): string | null {
+  const dateString = targetDate.replace(/\([^)]*\)/, "");
+  const date = parse(dateString, "yyyy/M/d", new Date());
+
+  const result = holidays.find(
+    (holiday) => holiday.date === format(date, "yyyy-MM-dd"),
+  );
+  return result ? result.name : null;
+}

--- a/src/utils/holiday.ts
+++ b/src/utils/holiday.ts
@@ -23,12 +23,17 @@ export function isHolidayMonday(
 export function getHolidayName(
   targetDate: string,
   holidays: Holiday[],
-): string | null {
+): string {
   const dateString = targetDate.replace(/\([^)]*\)/, "");
   const date = parse(dateString, "yyyy/M/d", new Date());
 
   const result = holidays.find(
     (holiday) => holiday.date === format(date, "yyyy-MM-dd"),
   );
-  return result ? result.name : null;
+
+  if (!result) {
+    throw new Error(`Holiday not found for date: ${targetDate}`);
+  }
+
+  return result.name;
 }

--- a/src/utils/holiday.ts
+++ b/src/utils/holiday.ts
@@ -1,0 +1,21 @@
+import { format, isMonday, parse } from "date-fns";
+
+type Holiday = {
+  date: string;
+  name: string;
+};
+
+export function isHolidayMonday(
+  targetDate: string,
+  holidays: Holiday[],
+): boolean {
+  const dateString = targetDate.replace(/\([^)]*\)/, "");
+  const date = parse(dateString, "yyyy/M/d", new Date());
+
+  const isMondayFlag = isMonday(date);
+  const isHolidayFlag = holidays.some(
+    (holiday) => holiday.date === format(date, "yyyy-MM-dd"),
+  );
+
+  return isMondayFlag && isHolidayFlag;
+}

--- a/src/utils/member.test.ts
+++ b/src/utils/member.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vitest";
-import { generateCTSchedules, generateRoundRobinPairs, Round } from "@/src/utils/member";
+import {
+  generateCTSchedules,
+  generateRoundRobinPairs,
+  Round,
+} from "@/src/utils/member";
 import { mondays } from "@/src/utils/date";
 import { User } from "@/app/actions";
 
@@ -7,7 +11,7 @@ import { User } from "@/app/actions";
 const createUser = (
   id: number,
   name: string,
-  participate: boolean = true
+  participate: boolean = true,
 ): User => ({
   id,
   slack_user_id: `U${id.toString().padStart(10, "0")}`,
@@ -106,11 +110,11 @@ describe("generateRoundRobinPairs", () => {
   test("奇数は(n-1),偶数はnラウンド生成の検証", () => {
     [3, 4, 5, 6].forEach((participantCount) => {
       const participants = Array.from({ length: participantCount }, (_, i) =>
-        createUser(i + 1, `Member${i + 1}`)
+        createUser(i + 1, `Member${i + 1}`),
       );
       const result = generateRoundRobinPairs(participants);
       expect(result).toHaveLength(
-        participantCount % 2 ? participantCount : participantCount - 1
+        participantCount % 2 ? participantCount : participantCount - 1,
       );
     });
   });
@@ -210,5 +214,30 @@ describe("generateCTSchedules", () => {
     expect(result[0].date).toBe(mondays[0]);
     expect(result[1].date).toBe(mondays[1]);
     expect(result[2].date).toBe(mondays[2]);
+  });
+
+  test("祝日スキップしてもラウンドがずれない", () => {
+    const dateList = ["2025/8/4(月)", "2025/8/11(月)", "2025/8/18(月)"];
+    const holidays = [{ date: "2025-08-11", name: "山の日" }];
+    const rounds: Round[] = [
+      [
+        [alice, bob],
+        [charlie, null],
+      ],
+      [
+        [alice, charlie],
+        [bob, null],
+      ],
+      [
+        [bob, charlie],
+        [alice, null],
+      ],
+    ];
+    const result = generateCTSchedules(rounds, dateList, holidays);
+
+    expect(result[1].round).toBe(null);
+    expect(result[1].isHoliday).toBe(true);
+    expect(result[0].round).toBe(rounds[0]);
+    expect(result[2].round).toBe(rounds[1]);
   });
 });

--- a/src/utils/member.test.ts
+++ b/src/utils/member.test.ts
@@ -158,9 +158,9 @@ describe("generateCTSchedules", () => {
       ],
     ];
     const expectedThreeSchedules = [
-      { date: "2025/8/4(月)", round: threePersonRounds[0] },
-      { date: "2025/8/11(月)", round: threePersonRounds[1] },
-      { date: "2025/8/18(月)", round: threePersonRounds[2] },
+      { date: "2025/8/4(月)", isHoliday: false, round: threePersonRounds[0] },
+      { date: "2025/8/11(月)", isHoliday: false, round: threePersonRounds[1] },
+      { date: "2025/8/18(月)", isHoliday: false, round: threePersonRounds[2] },
     ];
     const result = generateCTSchedules(threePersonRounds, testData);
 

--- a/src/utils/member.ts
+++ b/src/utils/member.ts
@@ -111,7 +111,6 @@ export function generateCTSchedules(
   return dateList.map((date) => {
     // 祝日の処理
     if (isHolidayMonday(date, holidays)) {
-      console.log("isHolidayMonday");
       const holidayName = getHolidayName(date, holidays);
       return { date, round: null, isHoliday: true, holidayName };
     }

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/cron/notify-ct-pairs",
       "schedule": "0 2 * * 1"
+    },
+    {
+      "path": "/api/cron/sync-holidays",
+      "schedule": "0 0 1 * *"
     }
   ]
 }


### PR DESCRIPTION
close #23

## やったこと
- Google カレンダーから祝日を取得して DB に保存
  - cron で月1回実行
  - 「ひな祭り」「七夕」など `その他の行事` は除外
- 祝日はラウンドが進まないようにする
- 祝日は Slack 通知を停止
- 祝日の UI 表示
- テストの追加・修正

<img width="1064" height="776" alt="スクリーンショット 2026-02-24 19 26 44" src="https://github.com/user-attachments/assets/cf0f0b8d-858f-4ac6-a63f-ac7b1f7ae6fc" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core schedule generation to insert holiday weeks (no round) and adds new cron-based holiday sync that writes to the database and affects Slack notifications, so incorrect holiday data or logic could shift schedules or suppress messages.
> 
> **Overview**
> Adds **holiday awareness** to CT scheduling: `generateCTSchedules` now accepts a holiday list and marks holiday Mondays as `{ isHoliday: true, round: null, holidayName }`, advancing the round pointer only on non-holidays so pair order doesn’t drift.
> 
> Introduces a **holiday sync pipeline**: fetches Japanese national holidays from Google Calendar (filtering out non-national events), upserts them into a new `holidays` table via server actions, and schedules a monthly Vercel cron (`/api/cron/sync-holidays`).
> 
> Updates the app and cron notifier to use DB-backed holidays: the homepage highlights holiday cards, and `/api/cron/notify-ct-pairs` skips Slack posting on holidays (with safer 401 response and nullable `round` handling).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 053e5f81e33744929e5abd502a1115b7db68c7e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->